### PR TITLE
Add a basic page for updating tournament seed/place

### DIFF
--- a/layouts/editTournamentResult.html
+++ b/layouts/editTournamentResult.html
@@ -1,0 +1,24 @@
+{{ define "title" }}Edit Tournament Result{{ end }}
+{{ define "content" }}
+<h1>Edit Tournament Result</h1>
+
+<div>Tournament: {{.Tournament.Name}}</div>
+<div>Player: {{.Player.Nickname}}</div>
+
+<form action="/save/tournamentresult/edit/{{.TournamentResult.ID}}" method="POST">
+  <div class="form-group">
+    <label for="seed" class="col-sm-2 control-label">Seed</label>
+    <div class="col-sm-10">
+      <input type="number" class="form-control" placeholder="Seed" name="seed" id="seed" value="{{.TournamentResult.Seed}}">
+    </div>
+  </div>
+  <div class="form-group">
+    <label for="place" class="col-sm-2 control-label">Place</label>
+    <div class="col-sm-10">
+      <input type="number" class="form-control" placeholder="Place" name="place" id="place" value="{{.TournamentResult.Place}}">
+    </div>
+  </div>
+  <button type="submit" class="btn btn-default">Save</button>
+  </div>
+</form>
+{{ end }}

--- a/layouts/viewTournament.html
+++ b/layouts/viewTournament.html
@@ -30,6 +30,9 @@
     <div>
       {{.Place}} - Seeded {{.Seed}}
       - <a href="/player/{{$p.URLPath}}">{{$p.Nickname}}</a>
+      {{if $.IsLoggedIn}}
+      <a href="/tournamentresult/edit/{{.ID}}">[Edit]</a>
+      {{end}}
     </div>
   {{end}}
 

--- a/main.go
+++ b/main.go
@@ -177,6 +177,10 @@ func main() {
 	r.HandleFunc("/tournament/delete/{tournament:[-a-zA-Z0-9]+}", isAdminMiddleware(deleteTournamentHandler))
 	r.HandleFunc("/save/tournament/delete/{tournament:[-a-zA-Z0-9]+}", isAdminMiddleware(saveDeleteTournamentHandler))
 
+	// Tournament results
+	r.HandleFunc("/tournamentresult/edit/{result:[-a-zA-Z0-9]+}", isAdminMiddleware(editTournamentResultHandler))
+	r.HandleFunc("/save/tournamentresult/edit/{result:[-a-zA-Z0-9]+}", isAdminMiddleware(saveEditTournamentResultHandler))
+
 	// Merge players
 	r.HandleFunc("/players/merge", isAdminMiddleware(mergePlayersHandler))
 	r.HandleFunc("/save/merge/players", isAdminMiddleware(saveMergePlayersHandler))


### PR DESCRIPTION
Add a page that allows you to change the seed/place of a tournament result. It could be expanded to changing the player later, but right now it's useful for updating results to reflect pot splits.
