### PR TITLE
Split out matches by game on player and faceoff

### DIFF
--- a/gametype.go
+++ b/gametype.go
@@ -32,6 +32,20 @@ func fetchGameTypes() []GameType {
 	return gameTypes
 }
 
+func fetchGameType(ID string) (*GameType, error) {
+	c, err := getGameTypeTable().Get(ID).Run(dataStore.GetSession())
+	defer c.Close()
+	if err != nil {
+		return nil, err
+	}
+	var gt *GameType
+	err = c.One(&gt)
+	if err != nil {
+		return nil, err
+	}
+	return gt, nil
+}
+
 func fetchGameTypeByURLPath(p string) (*GameType, error) {
 	c, err := getGameTypeTable().Filter(map[string]interface{}{
 		"urlpath": p,

--- a/layouts/faceoff.html
+++ b/layouts/faceoff.html
@@ -22,36 +22,39 @@
   <button type="submit" class="btn btn-default">Submit</button>
 </form>
 {{ with .Matches }}
-  <div>
-    <span>Sets: </span>
-    <span>{{$.Player1Sets}} - {{$.Player2Sets}}</span>
-  </div>
-  <div>
-    <span>Matches: </span>
-    <span>{{$.Player1Games}} - {{$.Player2Games}}</span>
-  </div>
-  <p>
   {{ range . }}
+    <strong>{{.GameType.Name}}</strong>
     <div>
-    {{if eq $.Player1.ID .Player1}}
-      {{if gt .Player1score .Player2score }}
-        <span>{{$.Player1.Nickname}}</span>
-        <span>({{ .Player1score }} - {{ .Player2score }})</span>
-      {{else}}
-        <span>{{$.Player2.Nickname}}</span>
-        <span>({{ .Player2score }} - {{ .Player1score }})</span>
-      {{end}}
-    {{else}}
-      {{if gt .Player1score .Player2score }}
-        <span>{{$.Player2.Nickname}}</span>
-        <span>({{ .Player1score }} - {{ .Player2score }})</span>
-      {{else}}
-        <span>{{$.Player1.Nickname}}</span>
-        <span>({{ .Player2score }} - {{ .Player1score }})</span>
-      {{end}}
-    {{end}}
-    <span>{{.Date.Month}} {{.Date.Day}}, {{.Date.Year}}</span>
+      <span>Sets: </span>
+      <span>{{.Player1Sets}} - {{.Player2Sets}}</span>
     </div>
+    <div>
+      <span>Matches: </span>
+      <span>{{.Player1Games}} - {{.Player2Games}}</span>
+    </div>
+    <p>
+    {{ range .Matches }}
+      <div>
+      {{if eq $.Player1.ID .Player1}}
+        {{if gt .Player1score .Player2score }}
+          <span>{{$.Player1.Nickname}}</span>
+          <span>({{ .Player1score }} - {{ .Player2score }})</span>
+        {{else}}
+          <span>{{$.Player2.Nickname}}</span>
+          <span>({{ .Player2score }} - {{ .Player1score }})</span>
+        {{end}}
+      {{else}}
+        {{if gt .Player1score .Player2score }}
+          <span>{{$.Player2.Nickname}}</span>
+          <span>({{ .Player1score }} - {{ .Player2score }})</span>
+        {{else}}
+          <span>{{$.Player1.Nickname}}</span>
+          <span>({{ .Player2score }} - {{ .Player1score }})</span>
+        {{end}}
+      {{end}}
+      <span>{{.Date.Month}} {{.Date.Day}}, {{.Date.Year}}</span>
+      </div>
+    {{ end }}
   {{ end }}
   </p>
 {{ end }}

--- a/layouts/player.html
+++ b/layouts/player.html
@@ -16,47 +16,53 @@
 {{with .Results}}
 <h3>Recent Results</h3>
 {{range .}}
-<div>
-  {{.Place}} - <a href="/tournament/{{.Tournament.ID}}">{{.Tournament.Name}}</a>
-  - {{.Tournament.DateStart.Month}} {{.Tournament.DateStart.Day}}, {{.Tournament.DateStart.Year}}
-</div>
+<strong>{{.GameType.Name}}</strong>
+  {{range .Results}}
+  <div>
+    {{.Place}} - <a href="/tournament/{{.Tournament.ID}}">{{.Tournament.Name}}</a>
+    - {{.Tournament.DateStart.Month}} {{.Tournament.DateStart.Day}}, {{.Tournament.DateStart.Year}}
+  </div>
+  {{end}}
 {{end}}
 {{end}}
 
 {{with .Matches}}
 <h3>Recent Matches</h3>
 {{range .}}
-<div>
-  {{$p1 := index $.PlayerMap .Player1}}
-  {{$p2 := index $.PlayerMap .Player2}}
-  {{if eq $p1.ID $.Player.ID}}
-    {{if gt .Player1score .Player2score}}
-      W
+<strong>{{.GameType.Name}}</strong>
+  {{range .Matches}}
+  <div>
+    {{$p1 := index $.PlayerMap .Player1}}
+    {{$p2 := index $.PlayerMap .Player2}}
+    {{if eq $p1.ID $.Player.ID}}
+      {{if gt .Player1score .Player2score}}
+        W
+      {{else}}
+        L
+      {{end}}
+      vs. <span>
+        <a href="/player/{{$p2.URLPath}}">{{$p2.Nickname}}</a>
+          ({{.Player1score}}-{{.Player2score}})
+        </span>
     {{else}}
-      L
+      {{if gt .Player2score .Player1score}}
+        W
+      {{else}}
+        L
+      {{end}}
+      vs. <span>
+        <a href="/player/{{$p1.URLPath}}">{{$p1.Nickname}}</a>
+        ({{.Player2score}}-{{.Player1score}})
+        </span>
     {{end}}
-    vs. <span>
-      <a href="/player/{{$p2.URLPath}}">{{$p2.Nickname}}</a>
-        ({{.Player1score}}-{{.Player2score}})
-      </span>
-  {{else}}
-    {{if gt .Player2score .Player1score}}
-      W
-    {{else}}
-      L
+    {{if .Hidden}}
+    (Hidden)
     {{end}}
-    vs. <span>
-      <a href="/player/{{$p1.URLPath}}">{{$p1.Nickname}}</a>
-      ({{.Player2score}}-{{.Player1score}})
-      </span>
+    {{if $.CanEdit}}
+    <a href="/edit/match/{{.ID}}">[Edit]</a>
+    {{end}}
+  </div>
   {{end}}
-  {{if .Hidden}}
-  (Hidden)
-  {{end}}
-  {{if $.CanEdit}}
-  <a href="/edit/match/{{.ID}}">[Edit]</a>
-  {{end}}
-</div>
 {{end}}
 {{end}}
 {{ end }}

--- a/layouts/viewTournament.html
+++ b/layouts/viewTournament.html
@@ -2,6 +2,7 @@
 
 {{ define "content" }}
   <h1>{{.Tournament.Name}}</h1>
+  <h3>{{.GameType.Name}}</h3>
 
   {{with .PoolOf}}
   <p>Pool of:

--- a/tournament.go
+++ b/tournament.go
@@ -551,11 +551,13 @@ func viewTournamentHandler(w http.ResponseWriter, r *http.Request) {
 		poolOf, _ = fetchTournament(t.PoolOf)
 	}
 
+	gametype, _ := fetchGameType(t.GameType)
 	pools, _ := fetchTournamentPools(t.ID)
 	results, _ := fetchResultsForTournament(t.ID)
 
 	data := struct {
 		Tournament *Tournament
+		GameType   *GameType
 		PoolOf     *Tournament
 		Pools      []*Tournament
 		Results    []*TournamentResult
@@ -564,6 +566,7 @@ func viewTournamentHandler(w http.ResponseWriter, r *http.Request) {
 		IsLoggedIn bool
 	}{
 		t,
+		gametype,
 		poolOf,
 		pools,
 		results,


### PR DESCRIPTION
We already support multiple game types, but the results are interleaved on the player page and the faceoff page. This branch splits them out so it's more obvious which results are for which game.
