### PR TITLE
Switch to library that supports smash gg

### DIFF
--- a/layouts/addPool.html
+++ b/layouts/addPool.html
@@ -5,7 +5,7 @@
 <form action="/save/addpool" method="POST">
   <input type="hidden" name="poolOf" value="{{.Tournament.ID}}">
   <input id="name" name="name" placeholder="Name" />
-  <input id="url" name="url" placeholder="Challonge Url" />
+  <input id="url" name="url" placeholder="Challonge or Smash.GG URL" />
   <div>
     <input type="submit" value="Save">
   </div>

--- a/layouts/addTournament.html
+++ b/layouts/addTournament.html
@@ -16,8 +16,8 @@
     </select>
   </div>
   <div class="form-group">
-    <label for="url">Challonge URL</label>
-    <input id="url" class="form-control" name="url" placeholder="Challonge URL" />
+    <label for="url">Challonge or Smash.GG URL</label>
+    <input id="url" class="form-control" name="url" placeholder="Challonge or Smash.GG URL" />
   </div>
   <div class="form-group">
     <label for="city">City</label>

--- a/layouts/addTournamentMatch.html
+++ b/layouts/addTournamentMatch.html
@@ -25,17 +25,17 @@
         <td class="col-md-4">
           <div class="input-group">
             <span class="input-group-addon">
-              <input type="radio" name="p_{{.Id}}" value="new" checked>
+              <input type="radio" name="p_{{.ID}}" value="new" checked>
             </span>
-            <input type="text" class="form-control" name="newname_p_{{.Id}}" value="{{.Name}}">
+            <input type="text" class="form-control" name="newname_p_{{.ID}}" value="{{.Name}}">
           </div>
         </td>
         <td class="col-md-4">
           <div class="col-md-1">
-            <input type="radio" name="p_{{.Id}}" value="select">
+            <input type="radio" name="p_{{.ID}}" value="select">
           </div>
           <div class="col-md-8">
-            <select class="form-control" name="select_p_{{.Id}}">
+            <select class="form-control" name="select_p_{{.ID}}">
             </select>
           </div>
         </td>


### PR DESCRIPTION
We'd like to be able to support smash.gg tournament brackets as well. This PR switches to using a new library that takes both Challonge and Smash.GG urls and returns tournament results in a single format: https://github.com/dguenther/go-bracket/
